### PR TITLE
hotfix: depracate `MoisesWorkflowEnum`

### DIFF
--- a/lib/src/domain/enums/moises_worklflow_enum.dart
+++ b/lib/src/domain/enums/moises_worklflow_enum.dart
@@ -1,8 +1,6 @@
-/// # Moises Template workflows
-/// The following workflows are available to all platform users.
-/// Public workflows are under the `moises` namespace.
-///
-/// Check for more info : [docs/template-workflows](https://music.ai/workflows/)
+/// # Deprecated - Moises Template workflows
+@Deprecated(
+    'Use the workflow name - Check for more info : https://music.ai/workflows/')
 enum MoisesWorkflowEnum {
   /// ## Stems Vocals Accompaniment
   ///


### PR DESCRIPTION
# Depracate `MoisesWorkflowEnum`
No more enum or specification is needed, the actual workflow name can be used.